### PR TITLE
fix: resolve file:// URLs before deriving the namespace

### DIFF
--- a/src/filePathToNamespace.test.ts
+++ b/src/filePathToNamespace.test.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 
 import { filePathToNamespace } from "./filePathToNamespace.js";
@@ -28,5 +29,21 @@ describe("filePathToNamespace", () => {
 		const actual = filePathToNamespace("abc/def");
 
 		expect(actual).toBe("xyz:def");
+	});
+
+	it("resolves a file:// URL to its package path when given import.meta.url", () => {
+		mockReadPackageUpSync.mockReturnValueOnce({
+			packageJson: { name: "xyz" },
+			path: "/repo/pkg/package.json",
+		});
+
+		const actual = filePathToNamespace(
+			pathToFileURL("/repo/pkg/lib/sub/file.js").href,
+		);
+
+		expect(mockReadPackageUpSync).toHaveBeenCalledWith({
+			cwd: "/repo/pkg/lib/sub",
+		});
+		expect(actual).toBe("xyz:sub:file");
 	});
 });

--- a/src/filePathToNamespace.ts
+++ b/src/filePathToNamespace.ts
@@ -1,20 +1,25 @@
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import { readPackageUpSync } from "read-package-up";
 
 import { generateNamespace } from "./generateNamespace.js";
 
 export function filePathToNamespace(filePath: string) {
+	const resolved = filePath.startsWith("file:")
+		? fileURLToPath(filePath)
+		: filePath;
+
 	const packageUp = readPackageUpSync({
-		cwd: path.dirname(filePath),
+		cwd: path.dirname(resolved),
 	});
 
 	if (!packageUp) {
-		return generateNamespace(filePath);
+		return generateNamespace(resolved);
 	}
 
 	const filePathRelative = path.relative(
 		path.dirname(packageUp.path),
-		filePath,
+		resolved,
 	);
 
 	return generateNamespace(filePathRelative, packageUp.packageJson.name);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #504
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/debug-for-file/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/debug-for-file/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`filePathToNamespace` is handed `import.meta.url` (a `file://` URL) but passed it straight to `path.dirname` / `path.relative`.
A `file://` URL isn't an absolute path, so `read-package-up` resolved its `cwd` against `process.cwd()` and found whichever `package.json` sat above the *working directory* rather than the file's own.
Result: a package run as a dependency from another project got the **consumer's** name plus a `file:`-laden path (e.g. `sentry:file:Users:…:run-on-changed:lib:runOnChanged`) instead of `run-on-changed:runOnChanged`, so `DEBUG=run-on-changed:*` never matched. It only looked correct when `cwd` happened to be inside the file's own package (dev/tests).

This converts a `file:` URL to a real path with `fileURLToPath` before any `path` operation, anchoring resolution to the file. Plain-path inputs (and the existing tests) are unaffected.

Verified with a new test (asserts `read-package-up` is called with the file's own directory and that the namespace is correct), and end-to-end: the same file URL now resolves to the same clean namespace from any working directory.

🎯
