### PR TITLE
refactor: replace `read-package-up` with `empathic`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 	"dependencies": {
 		"@types/debug": "^4.1.12",
 		"debug": "^4.4.3",
-		"read-package-up": "^12.0.0"
+		"empathic": "^2.0.1"
 	},
 	"devDependencies": {
 		"@eslint-community/eslint-plugin-eslint-comments": "4.7.0",
@@ -61,6 +61,7 @@
 		"eslint-plugin-perfectionist": "5.9.0",
 		"eslint-plugin-regexp": "3.1.0",
 		"eslint-plugin-yml": "3.4.0",
+		"fs-fixture": "^2.14.0",
 		"husky": "9.1.7",
 		"knip": "6.17.1",
 		"lint-staged": "17.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,9 @@ importers:
       debug:
         specifier: ^4.4.3
         version: 4.4.3
-      read-package-up:
-        specifier: ^12.0.0
-        version: 12.0.0
+      empathic:
+        specifier: ^2.0.1
+        version: 2.0.1
     devDependencies:
       '@eslint-community/eslint-plugin-eslint-comments':
         specifier: 4.7.0
@@ -72,6 +72,9 @@ importers:
       eslint-plugin-yml:
         specifier: 3.4.0
         version: 3.4.0(eslint@10.5.0(jiti@2.7.0))
+      fs-fixture:
+        specifier: ^2.14.0
+        version: 2.14.0
       husky:
         specifier: 9.1.7
         version: 9.1.7
@@ -2366,6 +2369,10 @@ packages:
     resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
     engines: {node: '>=18.3.0'}
     hasBin: true
+
+  fs-fixture@2.14.0:
+    resolution: {integrity: sha512-lZBaSOewY5snBSyOjn3fmo2ES5gOR7Q1Y6dILH0/xR0xejjUhux65OGaFWhQ+jiyvTi5HOHqXQrQ9v48Lsmqbw==}
+    engines: {node: '>=18.0.0'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -6451,6 +6458,8 @@ snapshots:
   formatly@0.3.0:
     dependencies:
       fd-package-json: 2.0.0
+
+  fs-fixture@2.14.0: {}
 
   fsevents@2.3.3:
     optional: true

--- a/src/filePathToNamespace.test.ts
+++ b/src/filePathToNamespace.test.ts
@@ -1,49 +1,42 @@
-import { pathToFileURL } from "node:url";
-import { describe, expect, it, vi } from "vitest";
+import { createFixture } from "fs-fixture";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
 
 import { filePathToNamespace } from "./filePathToNamespace.js";
 
-const mockReadPackageUpSync = vi.fn();
-
-vi.mock("read-package-up", () => ({
-	get readPackageUpSync() {
-		return mockReadPackageUpSync;
-	},
-}));
-
 describe("filePathToNamespace", () => {
-	it("generates a namespace with just the filePath when readPackageUpSync doesn't resolve a package.json", () => {
-		mockReadPackageUpSync.mockReturnValueOnce(undefined);
+	it("generates a namespace with just the filePath when readPackageUpSync doesn't resolve a package.json", async () => {
+		await using fixture = await createFixture({
+			"abc/def/file.js": 'console.log("Hello world")',
+		});
 
-		const actual = filePathToNamespace("abc/def");
+		const actual = filePathToNamespace("abc/def", fixture.path);
 
 		expect(actual).toBe("abc:def");
 	});
 
-	it("generates a namespace including the package name when readPackageUpSync resolves a package.json", () => {
-		mockReadPackageUpSync.mockReturnValueOnce({
-			packageJson: { name: "xyz" },
-			path: "abc/package.json",
+	it("generates a namespace including the package name when readPackageUpSync resolves a package.json", async () => {
+		await using fixture = await createFixture({
+			"abc/def.js": 'console.log("Hello world")',
+			"abc/package.json": JSON.stringify({ name: "xyz" }),
 		});
 
-		const actual = filePathToNamespace("abc/def");
+		const actual = filePathToNamespace("abc/def.js", fixture.path);
 
 		expect(actual).toBe("xyz:def");
 	});
 
-	it("resolves a file:// URL to its package path when given import.meta.url", () => {
-		mockReadPackageUpSync.mockReturnValueOnce({
-			packageJson: { name: "xyz" },
-			path: "/repo/pkg/package.json",
+	it("resolves a file:// URL to its package path when given import.meta.url", async () => {
+		await using fixture = await createFixture({
+			"package.json": JSON.stringify({ name: "root" }),
+			"repo/pkg/lib/sub/file.js": 'console.log("Hello world")',
+			"repo/pkg/package.json": JSON.stringify({ name: "xyz" }),
 		});
 
 		const actual = filePathToNamespace(
-			pathToFileURL("/repo/pkg/lib/sub/file.js").href,
+			path.join(fixture.path, "repo/pkg/lib/sub/file.js"),
 		);
 
-		expect(mockReadPackageUpSync).toHaveBeenCalledWith({
-			cwd: "/repo/pkg/lib/sub",
-		});
 		expect(actual).toBe("xyz:sub:file");
 	});
 });

--- a/src/filePathToNamespace.ts
+++ b/src/filePathToNamespace.ts
@@ -1,26 +1,37 @@
+import { up } from "empathic/package";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { readPackageUpSync } from "read-package-up";
 
 import { generateNamespace } from "./generateNamespace.js";
 
-export function filePathToNamespace(filePath: string) {
-	const resolved = filePath.startsWith("file:")
+export function filePathToNamespace(filePath: string, cwd = process.cwd()) {
+	const barePath = filePath.startsWith("file:")
 		? fileURLToPath(filePath)
 		: filePath;
+	const resolved = !path.isAbsolute(barePath)
+		? path.join(
+				cwd,
+				barePath.startsWith("file:") ? fileURLToPath(barePath) : barePath,
+			)
+		: barePath;
 
-	const packageUp = readPackageUpSync({
-		cwd: path.dirname(resolved),
-	});
+	const manifestPath = up({ cwd: resolved });
 
-	if (!packageUp) {
-		return generateNamespace(resolved);
+	if (!manifestPath) {
+		return generateNamespace(barePath);
 	}
 
-	const filePathRelative = path.relative(
-		path.dirname(packageUp.path),
-		resolved,
-	);
+	const filePathRelative = path.relative(path.dirname(manifestPath), resolved);
+	const manifest = safeParseManifest(manifestPath);
 
-	return generateNamespace(filePathRelative, packageUp.packageJson.name);
+	return generateNamespace(filePathRelative, manifest?.name);
+}
+
+function safeParseManifest(filePath: string): undefined | { name?: string } {
+	try {
+		return JSON.parse(fs.readFileSync(filePath, "utf8")) as never;
+	} catch {
+		return undefined;
+	}
 }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to debug-for-file! 🧶
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #485
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/debug-for-file/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/debug-for-file/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

this PR replaces `read-package-up` with `empathic` rather than `node:modules#findPackageJSON`.

it also refactors the tests to properly test the directory walking and file finding, rather than mocking the results.

the reasoning for using `empathic` is that `findPackageJSON` is still experimental, and seems to not be very good at the moment. i could not for the life of me get the proper tests to pass, with the errors being stuff like "The URL must be of scheme file" when the docs say it accepts FS paths.

[`empathic`](https://npmx.dev/package/empathic) is a teeny-tiny 20kb library for walking directories, used by projects like Storybook.

we could also inline what we use from `empathic` and bring it down to 2kb~ which makes any node_module deduplication not matter anymore.

---

i also saw that you're building and including the source maps in the published package, do you feel strongly that they help?
they make up 10 out of the 14kb in the published package.

---

you could also think about replacing debug with [obug](https://npmx.dev/package/obug), the vite folks' more modern debug fork.