### PR TITLE
feat: use node:module's native findPackageJSON

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -50,6 +50,12 @@ export default defineConfig(
 
 			// https://github.com/eslint-community/eslint-plugin-n/issues/472
 			"n/no-unpublished-bin": "off",
+
+			// Deliberately adopted while still experimental: https://github.com/JoshuaKGoldberg/debug-for-file/issues/485
+			"n/no-unsupported-features/node-builtins": [
+				"error",
+				{ ignores: ["module.findPackageJSON"] },
+			],
 		},
 		settings: { perfectionist: { partitionByComment: true, type: "natural" } },
 	},

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
 	},
 	"dependencies": {
 		"@types/debug": "^4.1.12",
-		"debug": "^4.4.3",
-		"read-package-up": "^12.0.0"
+		"debug": "^4.4.3"
 	},
 	"devDependencies": {
 		"@eslint-community/eslint-plugin-eslint-comments": "4.7.0",
@@ -77,7 +76,7 @@
 	},
 	"packageManager": "pnpm@11.22.0",
 	"engines": {
-		"node": ">=18.3.0"
+		"node": ">=22.14.0"
 	},
 	"publishConfig": {
 		"provenance": true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       debug:
         specifier: ^4.4.3
         version: 4.4.3(supports-color@7.2.0)
-      read-package-up:
-        specifier: ^12.0.0
-        version: 12.0.0
     devDependencies:
       '@eslint-community/eslint-plugin-eslint-comments':
         specifier: 4.7.0

--- a/src/filePathToNamespace.test.ts
+++ b/src/filePathToNamespace.test.ts
@@ -1,49 +1,99 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { pathToFileURL } from "node:url";
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { filePathToNamespace } from "./filePathToNamespace.js";
 
-const mockReadPackageUpSync = vi.fn();
+const mockFindPackageJSON = vi.fn();
 
-vi.mock("read-package-up", () => ({
-	get readPackageUpSync() {
-		return mockReadPackageUpSync;
+vi.mock("node:module", () => ({
+	get findPackageJSON() {
+		return mockFindPackageJSON;
 	},
 }));
 
+let fixtures: string;
+
+function writeFixture(name: string, contents: unknown) {
+	const directory = path.join(fixtures, name);
+
+	fs.mkdirSync(directory, { recursive: true });
+
+	const packageJsonPath = path.join(directory, "package.json");
+
+	fs.writeFileSync(packageJsonPath, JSON.stringify(contents));
+
+	return packageJsonPath;
+}
+
+beforeAll(() => {
+	fixtures = fs.mkdtempSync(path.join(os.tmpdir(), "debug-for-file-"));
+});
+
+afterAll(() => {
+	fs.rmSync(fixtures, { force: true, recursive: true });
+});
+
 describe("filePathToNamespace", () => {
-	it("generates a namespace with just the filePath when readPackageUpSync doesn't resolve a package.json", () => {
-		mockReadPackageUpSync.mockReturnValueOnce(undefined);
+	it("generates a namespace with just the filePath when findPackageJSON doesn't resolve a package.json", () => {
+		mockFindPackageJSON.mockReturnValueOnce(undefined);
 
 		const actual = filePathToNamespace("abc/def");
 
 		expect(actual).toBe("abc:def");
 	});
 
-	it("generates a namespace including the package name when readPackageUpSync resolves a package.json", () => {
-		mockReadPackageUpSync.mockReturnValueOnce({
-			packageJson: { name: "xyz" },
-			path: "abc/package.json",
+	it("generates a namespace with just the filePath when findPackageJSON throws", () => {
+		mockFindPackageJSON.mockImplementationOnce(() => {
+			throw new Error("ERR_MODULE_NOT_FOUND");
 		});
 
 		const actual = filePathToNamespace("abc/def");
 
+		expect(actual).toBe("abc:def");
+	});
+
+	it("generates a namespace with just the filePath when findPackageJSON resolves a path that isn't a package.json", () => {
+		mockFindPackageJSON.mockReturnValueOnce("/repo/pkg/lib/sub/file.js");
+
+		const actual = filePathToNamespace("abc/def");
+
+		expect(actual).toBe("abc:def");
+	});
+
+	it("generates a namespace including the package name when findPackageJSON resolves a package.json", () => {
+		const packageJsonPath = writeFixture("named", { name: "xyz" });
+		mockFindPackageJSON.mockReturnValueOnce(packageJsonPath);
+
+		const actual = filePathToNamespace(path.join(fixtures, "named", "def.js"));
+
 		expect(actual).toBe("xyz:def");
 	});
 
-	it("resolves a file:// URL to its package path when given import.meta.url", () => {
-		mockReadPackageUpSync.mockReturnValueOnce({
-			packageJson: { name: "xyz" },
-			path: "/repo/pkg/package.json",
-		});
+	it("generates a namespace with just the relative filePath when the resolved package.json has no name", () => {
+		const packageJsonPath = writeFixture("unnamed", { private: true });
+		mockFindPackageJSON.mockReturnValueOnce(packageJsonPath);
 
 		const actual = filePathToNamespace(
-			pathToFileURL("/repo/pkg/lib/sub/file.js").href,
+			path.join(fixtures, "unnamed", "def.js"),
 		);
 
-		expect(mockReadPackageUpSync).toHaveBeenCalledWith({
-			cwd: "/repo/pkg/lib/sub",
-		});
+		expect(actual).toBe("def");
+	});
+
+	it("resolves a file:// URL to its package path when given import.meta.url", () => {
+		const packageJsonPath = writeFixture("url", { name: "xyz" });
+		mockFindPackageJSON.mockReturnValueOnce(packageJsonPath);
+		const filePath = path.join(fixtures, "url", "lib", "sub", "file.js");
+
+		const actual = filePathToNamespace(pathToFileURL(filePath).href);
+
+		expect(mockFindPackageJSON).toHaveBeenCalledWith(
+			".",
+			pathToFileURL(filePath),
+		);
 		expect(actual).toBe("xyz:sub:file");
 	});
 });

--- a/src/filePathToNamespace.ts
+++ b/src/filePathToNamespace.ts
@@ -1,6 +1,7 @@
+import * as fs from "node:fs";
+import { findPackageJSON } from "node:module";
 import * as path from "node:path";
-import { fileURLToPath } from "node:url";
-import { readPackageUpSync } from "read-package-up";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { generateNamespace } from "./generateNamespace.js";
 
@@ -9,18 +10,42 @@ export function filePathToNamespace(filePath: string) {
 		? fileURLToPath(filePath)
 		: filePath;
 
-	const packageUp = readPackageUpSync({
-		cwd: path.dirname(resolved),
-	});
+	const packageJsonPath = findClosestPackageJson(resolved);
 
-	if (!packageUp) {
+	if (!packageJsonPath) {
 		return generateNamespace(resolved);
 	}
 
 	const filePathRelative = path.relative(
-		path.dirname(packageUp.path),
+		path.dirname(packageJsonPath),
 		resolved,
 	);
 
-	return generateNamespace(filePathRelative, packageUp.packageJson.name);
+	return generateNamespace(filePathRelative, readPackageName(packageJsonPath));
+}
+
+function findClosestPackageJson(resolved: string) {
+	let found;
+
+	try {
+		// Passing the file as `base` rather than as `specifier` keeps this working
+		// for paths that don't exist on disk, which `specifier` would reject.
+		found = findPackageJSON(".", pathToFileURL(resolved));
+	} catch {
+		return undefined;
+	}
+
+	// Node resolves to the specifier itself, rather than `undefined` as
+	// documented, when no package.json exists in any parent directory.
+	return found !== undefined && path.basename(found) === "package.json"
+		? found
+		: undefined;
+}
+
+function readPackageName(packageJsonPath: string) {
+	const contents = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as {
+		name?: string;
+	};
+
+	return contents.name;
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #485
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/debug-for-file/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/debug-for-file/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Drops the `read-package-up` dependency in favor of [`module.findPackageJSON`](https://nodejs.org/docs/latest/api/module.html#modulefindpackagejsonspecifier-base), and bumps `engines.node` to `>=22.14.0` (the version that added it, alongside v23.2.0).

Two things about the native API made this less of a drop-in swap than I expected, so flagging them for review:

**It returns a path, not contents.** `readPackageUpSync` handed back the parsed `packageJson`; `findPackageJSON` returns only the path to the file, so the `name` is now read with `fs.readFileSync` + `JSON.parse`.

**It doesn't return `undefined` when nothing is found.** The docs say it returns `undefined` if no `package.json` is found, but on Node 24.13.1 it resolves to the specifier itself — I get back `/…/deep/file.js` for a file with no `package.json` in any parent. There's a `path.basename(found) === "package.json"` guard for that, without which every namespace outside a package would be derived from a non-`package.json` path.

It also requires a `file:` URL (plain absolute paths throw `ERR_UNSUPPORTED_RESOLVE_REQUEST`) and rejects specifiers that don't exist on disk. Passing the file as `base` with a `"."` specifier avoids that second constraint and, unlike a bare specifier, doesn't consult the package's `exports`.

## Behavior change

I diffed the old and new implementations over real fixture packages. They agree on every case I tried — including scoped names, `import.meta.url` input, a file with no `package.json` ancestor, and a nonexistent file inside a real directory — except one:

| Input | Before | After |
| --- | --- | --- |
| Path whose **directory** doesn't exist | `xyz:no:where:nope` | `:tmp:…:pkg:no:where:nope` |

`read-package-up` walked up the tree without touching the filesystem, so it resolved the package even for a fully imaginary path. `findPackageJSON` throws `ERR_MODULE_NOT_FOUND` there, which is caught and falls back to the bare-path namespace.

I left that as-is deliberately: restoring parity means reintroducing an `fs.existsSync` walk-up loop, which is the thing this change is meant to delete. It can't be hit through the documented usage (`debugForFile(import.meta.url)` always refers to a real file). Happy to add the loop back if you'd rather keep exact parity.

## Notes

`n/no-unsupported-features/node-builtins` flags `findPackageJSON` as experimental (Stability 1.1) regardless of the version range, so it's ignored for that one API in `eslint.config.ts` rather than disabled inline.

`read-package-up` stays in `pnpm-lock.yaml` as a transitive dependency of `create-typescript-app`; it's gone as a direct dependency.
